### PR TITLE
fix(#4): Fixes incorrect parsing of metadata

### DIFF
--- a/.versioning/changes/QM7uboGFvs.patch.md
+++ b/.versioning/changes/QM7uboGFvs.patch.md
@@ -1,0 +1,1 @@
+Fixes an issue where the metadata value was parsed as the pre-release value if the pre-release value was missing from the input [#4](https://github.com/gmbeard/semverutil/issues/4)

--- a/include/semverutil/utils.hpp
+++ b/include/semverutil/utils.hpp
@@ -43,7 +43,7 @@ template <typename InputIterator,
           typename OutputIterator>
 auto split_to(InputIterator i_first,
               InputIterator i_last,
-              Delim const& delim,
+              Delim delim,
               OutputIterator o_first,
               OutputIterator o_last,
               F transform) noexcept -> OutputIterator
@@ -56,8 +56,13 @@ auto split_to(InputIterator i_first,
     std::size_t n = 0;
 
     while (o_first != o_last) {
+        /* If there is only more space left in the output range then we just
+         * output the rest of the input, regardless of whether there are any
+         * more delimiters or not...
+         */
         if (std::next(o_first) == o_last)
             delim_pos = i_last;
+
         if constexpr (Transform<F, InputIterator>) {
             *o_first++ = transform(from, delim_pos);
         }
@@ -66,6 +71,7 @@ auto split_to(InputIterator i_first,
         }
 
         from = delim_pos != i_last ? ++delim_pos : delim_pos;
+
         delim_pos = std::find(from, i_last, delim);
 
         if (delim_pos == i_last && from == delim_pos)


### PR DESCRIPTION
Metadata was being incorrectly parsed as the pre-release value if the pre-release value was missing from the input.

closes #4 