### PR TITLE
feat(format_string): Adds additional FORMAT cmdline parameter

### DIFF
--- a/.versioning/changes/XHExk1Y6US.minor.md
+++ b/.versioning/changes/XHExk1Y6US.minor.md
@@ -1,0 +1,1 @@
+Adds a `+FORMAT` cmdline parameter that interprets `%`-prefixed sequences for more control of the output

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ install(TARGETS semverutilbin
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
+install(FILES "${PROJECT_SOURCE_DIR}/semverutil.1"
+    DESTINATION "${CMAKE_INSTALL_MANDIR}/man1/"
+)
+
 if(SEMVERUTIL_INSTALL_DEVEL)
     configure_package_config_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in"

--- a/README.md
+++ b/README.md
@@ -1,27 +1,41 @@
 ```
-SEMVERUTIL(1) General Commands Manual SEMVERUTIL(1)
+NAME
+       semverutil - Semantic version command line utility
 
-NAME 
- semverutil - Semantic version command line utility
+SYNOPSIS
+       semverutil [ -MNPR ] [+FORMAT]
 
-SYNOPSIS 
- semverutil [ -MNPR ]
+DESCRIPTION
+       semverutil  parses  semantic  version strings from STDIN and optionally
+       increments the major, minor, patch or revision. If no options are spec-
+       ified  then  semverutil will output the highest of the semantic version
+       values given in STDIN.
 
-DESCRIPTION 
- semverutil parses semantic version strings from STDIN and optionally increments the major, minor, patch,
- or revision. If no options are specified then semverutil will output the highest of the semantic version
- values given in STDIN.
+       semverutil includes an extension to the semver standard that allows re-
+       visions	-  an additional value to the immediate right-hand side of the
+       core version, separated by an underscore.
 
- semverutil includes an extension to the semver standard that allows revisions - an additional value to the
- immediate right-hand side of the core version, separated by an underscore.
+   Options
+       -M     Increment the major version
 
- Options
-   -M
-     Increment the major version
-   -N
-     Increment the minor version
-   -P
-     Increment the patch version
-   -R
-     Increment the revision
+       -N     Increment the minor version
+
+       -P     Increment the patch version
+
+       -R     Increment the revision
+
+   FORMAT
+       This controls the output. Interpreted sequences are:
+
+       %M     The MAJOR component
+
+       %N     The MINOR component
+
+       %P     The PATCH component
+
+       %R     The REVISION component
+
+       %L     The PRE-RELEASE component
+
+       %D     the METADATA component
 ```

--- a/include/semverutil/cmdline.hpp
+++ b/include/semverutil/cmdline.hpp
@@ -3,6 +3,8 @@
 
 #include <cinttypes>
 #include <span>
+#include <string_view>
+#include <vector>
 
 namespace semver
 {
@@ -19,9 +21,16 @@ enum : std::uint32_t
     increment_revision = 8,
 };
 
-}
+} // namespace CmdLineSwitches
 
-auto parse_cmdline(std::span<char const*> cmdline) noexcept -> std::uint32_t;
+struct ParseCmdLineResult
+{
+    std::uint32_t options;
+    std::vector<std::string_view> args;
+};
+
+auto parse_cmdline(std::span<char const*> cmdline) noexcept
+    -> ParseCmdLineResult;
 
 } // namespace semver
 

--- a/include/semverutil/detail/format.hpp
+++ b/include/semverutil/detail/format.hpp
@@ -1,0 +1,58 @@
+#ifndef SEMVERUTIL_DETAIL_FORMAT_HPP_INCLUDED
+#define SEMVERUTIL_DETAIL_FORMAT_HPP_INCLUDED
+
+#include <cstddef>
+#include <string_view>
+
+namespace semver::detail
+{
+
+template <typename UnaryFunction>
+auto parse_format_string(std::string_view input, UnaryFunction f) -> bool
+{
+    enum
+    {
+        Scanning,
+        VariablePrefix,
+        Variable,
+    } state = Scanning;
+
+    auto p = input.begin();
+    auto token_start = p;
+    auto data_end = input.end();
+    unsigned prefixed = 0;
+
+    while (p != data_end) {
+        switch (state) {
+        case Scanning:
+            if (*p == '%')
+                state = VariablePrefix;
+            else
+                ++p;
+            break;
+        case VariablePrefix:
+            prefixed = 1 - prefixed;
+            state = prefixed ? Variable : Scanning;
+            if (!f({ token_start, std::size_t(p - token_start) },
+                   static_cast<char>(0)))
+                return false;
+            token_start = ++p;
+            break;
+        case Variable:
+            ++p;
+            if (!f({ token_start, std::size_t(p - token_start) }, *token_start))
+                return false;
+            token_start = p;
+            state = Scanning;
+            prefixed = 0;
+            break;
+        }
+    }
+
+    if (!f({ token_start, std::size_t(p - token_start) }, static_cast<char>(0)))
+        return false;
+
+    return state == Scanning;
+}
+} // namespace semver::detail
+#endif // SEMVERUTIL_DETAIL_FORMAT_HPP_INCLUDED

--- a/include/semverutil/format.hpp
+++ b/include/semverutil/format.hpp
@@ -1,0 +1,14 @@
+#ifndef SEMVERUTIL_FORMAT_HPP_INCLUDED
+#define SEMVERUTIL_FORMAT_HPP_INCLUDED
+
+#include "./semver.hpp"
+#include <string>
+
+namespace semver
+{
+auto write_formatted(SemVer const& val,
+                     std::string_view format_string,
+                     std::string& output) -> bool;
+}
+
+#endif // SEMVERUTIL_FORMAT_HPP_INCLUDED

--- a/include/semverutil/semverutil.hpp
+++ b/include/semverutil/semverutil.hpp
@@ -1,6 +1,7 @@
 #ifndef SEMVERUTIL_SEMVERUTIL_HPP_INCLUDED
 #define SEMVERUTIL_SEMVERUTIL_HPP_INCLUDED
 
+#include "./format.hpp"
 #include "./semver.hpp"
 #include "./utils.hpp"
 

--- a/semverutil.1
+++ b/semverutil.1
@@ -2,7 +2,7 @@
 .SH NAME
 \fBsemverutil\fP - Semantic version command line utility
 .SH SYNOPSIS
-\fBsemverutil\fP [ -MNPR ]
+\fBsemverutil\fP [ -MNPR ] [+FORMAT]
 .SH DESCRIPTION
 \fBsemverutil\fP parses semantic version strings from \fBSTDIN\fP and optionally
 increments the major, minor, patch or revision. If no options are specified then
@@ -25,3 +25,25 @@ Increment the patch version
 .TP
 \fB-R\fP
 Increment the revision
+.PP
+.SS FORMAT
+.TP
+This controls the output. Interpreted sequences are:
+.TP
+%M
+The MAJOR component
+.TP
+%N
+The MINOR component
+.TP
+%P
+The PATCH component
+.TP
+%R
+The REVISION component
+.TP
+%L
+The PRE-RELEASE component
+.TP
+%D
+the METADATA component

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(
     semverutil
     cmdline.cpp
     detail/semver.cpp
+    format.cpp
     semver.cpp
     utils.cpp
 )

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -3,12 +3,19 @@
 namespace semver
 {
 
-auto parse_cmdline(std::span<char const*> cmdline) noexcept -> std::uint32_t
+auto parse_cmdline(std::span<char const*> cmdline) noexcept
+    -> ParseCmdLineResult
 {
     std::uint32_t opts = 0;
+    std::vector<std::string_view> args;
     for (auto param : cmdline) {
         if (*param == '\0')
             break;
+
+        if (*param == '+') {
+            args.push_back(param);
+            continue;
+        }
 
         if (*param++ != '-')
             continue;
@@ -30,7 +37,7 @@ auto parse_cmdline(std::span<char const*> cmdline) noexcept -> std::uint32_t
             }
         }
     }
-    return opts;
+    return { opts, std::move(args) };
 }
 
 } // namespace semver

--- a/src/format.cpp
+++ b/src/format.cpp
@@ -1,0 +1,44 @@
+#include "semverutil/format.hpp"
+#include "semverutil/detail/format.hpp"
+#include <sstream>
+
+auto semver::write_formatted(SemVer const& semver,
+                             std::string_view format_string,
+                             std::string& output) -> bool
+{
+    auto const handler = [&](std::string_view val, char token_type) {
+        if (token_type == 0) {
+            output += val;
+            return true;
+        }
+        std::stringstream writer {};
+        switch (token_type) {
+        case 'M':
+            writer << semver.major();
+            break;
+        case 'N':
+            writer << semver.minor();
+            break;
+        case 'P':
+            writer << semver.patch();
+            break;
+        case 'R':
+            writer << semver.revision();
+            break;
+        case 'L':
+            writer << semver.prerelease;
+            break;
+        case 'D':
+            writer << semver.metadata;
+            break;
+        default:
+            return false;
+        }
+
+        output += writer.str();
+
+        return true;
+    };
+
+    return detail::parse_format_string(format_string, handler);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,3 +47,8 @@ add_test(NAME invalid_core_version_tests
     COMMAND invalid_core_version_tests_wrapper.sh
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
+
+add_executable(format_string_tests format_string_tests.cpp)
+target_link_libraries(format_string_tests testing)
+add_test(NAME format_string_tests COMMAND format_string_tests)
+

--- a/tests/cmdline_tests.cpp
+++ b/tests/cmdline_tests.cpp
@@ -8,7 +8,7 @@ TEST_WITH_CONTEXT(should_parse_cmdline)
 {
     std::span<char const*> cmdline { test_context.argv,
                                      std::size_t(test_context.argc) };
-    auto opts = semver::parse_cmdline(cmdline);
+    auto const [opts, args] = semver::parse_cmdline(cmdline);
     EXPECT(opts & semver::CmdLineSwitches::increment_major);
     EXPECT(opts & semver::CmdLineSwitches::increment_minor);
     EXPECT(opts & semver::CmdLineSwitches::increment_patch);

--- a/tests/format_string_tests.cpp
+++ b/tests/format_string_tests.cpp
@@ -1,0 +1,20 @@
+#include "semverutil/detail/format.hpp"
+#include "testing.hpp"
+#include <iostream>
+
+auto should_parse_format_string()
+{
+    char const* kInput = "%%%M.%N.%P_%R-%L-%T";
+    auto success = semver::detail::parse_format_string(
+        kInput, [](std::string_view token, char chr) {
+            std::cerr << "- \"" << token << "\" " << (chr ? chr : '0') << '\n';
+            return true;
+        });
+
+    EXPECT(success);
+}
+
+auto main() -> int
+{
+    return semver::testing::run({ TEST(should_parse_format_string) });
+}


### PR DESCRIPTION
The optional FORMAT parameter interprets `%`-prefixed sequences to control the format of the output.